### PR TITLE
Assume `console` is called `after_action`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,36 @@
 # DevToolbar
-Firstdraft Dev Toolbar for cloud9 integration with better errors and web-console..etc..,
+
+This gem causes a toolbar to appear fixed to the right side of the viewport. It will
+
+ - Display a link to pop open an in-browser [web-console](https://github.com/rails/web-console).
+ - Display a link to `/rails/info` so you can check your routes.
+ - Display a link to `/admin` if [ActiveAdmin](https://github.com/activeadmin/activeadmin) is installed.
+ - Display a link to `/git` if [WebGit](https://github.com/firstdraft/web_git) is installed.
 
 ## Installation
-Add this line to your application's Gemfile:
+
+Add this line to your application's Gemfile, `bundle install`, and restart your server:
 
 ```ruby
+# Gemfile
+
 group :development do
   gem 'dev_toolbar', git: 'https://github.com/firstdraft/dev_toolbar.git'
 end
 ```
 
-And then execute:
-```bash
-$ bundle
+Add this line to your application controller:
+
+```ruby
+# app/controllers/application_controller.rb
+
+after_action :console
+```
+
+Add this line to your application layout:
+
+```html
+<!-- app/views/layouts/application.html.erb -->
+
+<%= dev_toolbar %>
 ```

--- a/app/assets/stylesheets/dev_toolbar/dev_toolbar.scss
+++ b/app/assets/stylesheets/dev_toolbar/dev_toolbar.scss
@@ -2,7 +2,7 @@
   box-sizing: border-box;
   position:fixed;
   height: 40px;
-  right:-40px;
+  right: 0px;
   top:45%;
   transform:rotate(-90deg);
   -webkit-transform:rotate(-90deg);
@@ -73,4 +73,3 @@
   background-color: #d9edf7;
   border-color: #bce8f1;
 }
-

--- a/app/views/shared/_dev_tools.html.erb
+++ b/app/views/shared/_dev_tools.html.erb
@@ -5,9 +5,6 @@
   <% end %>
 
   <% if defined?(WebConsole) %>
-    <% console %>
-
-
     <%= link_to "Console", "#", id: "console_button", class: "dev_tools_button btn btn-outline-secondary" %>
 
     <script>
@@ -29,10 +26,18 @@
       });
     </script>
   <% end %>
+
   <% if defined?(ActiveAdmin) %>
     <%= link_to "Admin", "/admin", class: "dev_tools_button btn btn-outline-secondary" %>
   <% end %>
+
   <%= link_to "Routes", "/rails/info", class: "dev_tools_button btn btn-outline-secondary" %>
 </div>
 
-<div class="footer alert-info" style="display: none;">Uh oh! Something went wrong. If you are the application owner, to get a more helpful error page please run this command at a terminal prompt: `bin/whitelist <%= request.ip %>`</div>
+<div class="footer alert-info" style="display: none;">
+  <p>To see a helpful <code>rails console</code> here, please run this command at a terminal prompt:</p>
+
+  <pre><code>bin/whitelist <%= request.ip %></code></pre>
+
+  <p>This console will have variables you've defined in the action, <code>params</code>, etc, available for you to play around with.</p>
+</div>

--- a/lib/dev_toolbar/middleware.rb
+++ b/lib/dev_toolbar/middleware.rb
@@ -27,11 +27,11 @@ module DevToolbar
     end
 
     def error_message
-  %Q{Uh oh! Something went wrong.
+  %Q{<p>Uh oh! You've got an error.</p>
 
- If you are the application owner, to get a more helpful error page please run this command at a terminal prompt:
+ <p>If you are the application owner, to get a more helpful error page please run this command at a terminal prompt:</p>
 
- `bin/whitelist #{@ip}`}
+ <pre><code>bin/whitelist #{@ip}</code></pre>}
     end
   end
 end


### PR DESCRIPTION
Calling `console` in the context of application layout doesn't appear to give access to local variables defined in the action, which would be helpful.

This change assumes something like `after_action :console` in `ApplicationController`. Needs testing.